### PR TITLE
Issue #35 and more

### DIFF
--- a/config_form.php
+++ b/config_form.php
@@ -1,49 +1,61 @@
 <?php $view = get_view();
-// TODO prefill certain fields with values in Options Table
+// Prefill fields with values stored previously
+// TODO Error handling
+$defaultLicenses = get_option(OPTION_LICENSES);
+$defaultFolder   = get_option(OPTION_FOLDER);
+$timeout         = get_option(OPTION_TIMEOUT);
+$customMessage   = file_get_contents(FILES_DIR . DIRECTORY_SEPARATOR
+                                    . SO_PLAYLIST. DIRECTORY_SEPARATOR
+                                    . SO_CUSTOM_MSG_FILE);
 ?>
-<div id="stream-only-plugin-warning">
-    <p>This plugin only works with themes that use Omeka-provided methods to output the HTML to display the files.
-    If the theme does not use these methods, the user will see errors when s/he clicks on links to audio files stored
-    as StreamOnly Items.</p>
+<div id="stream-only-plugin-theme-warning">
+    <p><?php echo __(SO_THEME_WARNING);?></p>
 </div>
 
 <div id="stream-only-plugin-settings">
 
-    <h2><?php echo __('License Settings'); ?></h2>
+    <h2><?php echo __(ELEMENT_LICENSE_COUNT_TITLE); ?></h2>
     <div class="field">
         <div class="two columns alpha">
-            <?php echo $view->formLabel(OPTION_LICENSES, __('# Streams (default)')); ?>
+            <?php echo $view->formLabel(OPTION_LICENSES, __(ELEMENT_LICENSE_COUNT)); ?>
         </div>
         <div class="inputs five columns omega">
             <?php echo $view->formText(OPTION_LICENSES, $defaultLicenses); ?>
         </div>
-        <div>Number of simultaneous listeners (not currently implemented).</div>
+        <div><?php echo __(ELEMENT_LICENSE_COUNT_DESCRIPTION);?></div>
     </div>
 
-    <h2><?php echo __('Folder for Storing Audio Files'); ?></h2>
+    <h2><?php echo __(ELEMENT_FOLDER_TITLE ); ?></h2>
     <div class="field">
         <div class="two columns alpha">
-            <?php echo $view->formLabel(OPTION_FOLDER, __('Folder Name')); ?>
+            <?php echo $view->formLabel(OPTION_FOLDER, __(ELEMENT_FOLDER)); ?>
         </div>
         <div class="inputs five columns omega">
             <?php echo $view->formText(OPTION_FOLDER, $defaultFolder); ?>
         </div>
-        <div><strong>***Folders should be chosen after consulting the server admin.***</strong></div>
+        <div><?php echo __(ELEMENT_FOLDER_DESCRIPTION_DEFAULT);?></div>
     </div>
 
-    <h2><?php echo __('Timeout'); ?></h2>
+    <h2><?php echo __(ELEMENT_TIMEOUT_TITLE); ?></h2>
     <div class="field">
         <div class="two columns alpha">
-            <?php echo $view->formLabel(OPTION_TIMEOUT, __('Timeout')); ?>
+            <?php echo $view->formLabel(OPTION_TIMEOUT, __(ELEMENT_TIMEOUT)); ?>
         </div>
         <div class="inputs five columns omega">
             <?php echo $view->formText(OPTION_TIMEOUT, $timeout); ?>
         </div>
+        <div><?php echo __(ELEMENT_TIMEOUT_DESCRIPTION);?></div>
     </div>
-    <div>Number of seconds after which the temporary files permitting access to the audio files
-         may be deleted. Setting a lower value may be helpful if your site gets a lot of activity,
-         or if you don't want one user to prevent others from listening to the audio file(s)
-         associated with the StreamOnly Item (latter not currently implemented).
+
+    <h2><?php echo __(ELEMENT_CUSTOM_MSG_TITLE); ?></h2>
+    <div class="field">
+        <div class="two columns alpha">
+            <?php echo $view->formLabel(OPTION_CUSTOM_MSG, __(ELEMENT_CUSTOM_MSG)); ?>
+        </div>
+        <div class="inputs five columns omega">
+            <?php echo $view->formTextarea(OPTION_CUSTOM_MSG, $customMessage); ?>
+        </div>
+        <div><?php echo __(ELEMENT_CUSTOM_MSG_DESCRIPTION);?></div>
     </div>
 
 </div>

--- a/helpers/StreamOnlyConstants.php
+++ b/helpers/StreamOnlyConstants.php
@@ -13,7 +13,16 @@ const SO_ITEM_TYPE_DESCRIPTION = 'Audio files stored in this Item Type cannot be
 const SO_PLUGIN_NAME = 'StreamOnly';
 const SO_PLUGIN_MODEL = 'StreamOnlyModel';
 
-// Elements
+// Displayed at the top of config_form.php
+const SO_THEME_WARNING =
+    "This plugin only works with themes that use Omeka-provided methods " .
+    "to output the HTML to display the files. " .
+    "If the theme does not use these methods, the user will see errors " .
+    "when s/he clicks on links to audio files stored as " .
+    "Items of Item Type StreamOnly.";
+
+// Elements made available for Items of ItemType StreamOnly
+// Not critical to the plugin
 const ELEMENT_TRANSCRIPTION = 'Transcription';
 const ELEMENT_TRANSCRIPTION_DESCRIPTION = 'Any written text transcribed from a sound';
 const ELEMENT_TRANSCRIPTION_FIELD = 'transcription';
@@ -26,32 +35,57 @@ const ELEMENT_DURATION_FIELD = 'duration';
 const ELEMENT_BIT_RATE = 'Bit Rate/Frequency';
 const ELEMENT_BIT_RATE_DESCRIPTION  = 'Rate at which bits are transferred (i.e. 96 kbit/s would be FM quality audio';
 const ELEMENT_BIT_RATE_FIELD = 'bit_rate/frequency';
-const ELEMENT_LICENSE_COUNT = 'Stream Only License Count';
+
+// Elements made available for Items of ItemType StreamOnly
+// CRITICAL to the plugin
+const ELEMENT_LICENSE_COUNT_TITLE = 'License Settings';
+const ELEMENT_LICENSE_COUNT = '# Licenses (default)';
 const ELEMENT_LICENSE_COUNT_DESCRIPTION = 'Number of simultaneous listeners permitted by licensing';
 const ELEMENT_LICENSE_COUNT_FIELD = 'stream-only-license-count';
-const ELEMENT_FOLDER = 'Stream Only Directory';
+
+const ELEMENT_FOLDER_TITLE = 'Folder for Storing Audio Files';
+const ELEMENT_FOLDER = 'Folder Name';
 const ELEMENT_FOLDER_DESCRIPTION =
     'The folder (relative to the account root) '.
     'where protected audio files will be stored. ' .
     'The default folder is set during configuration of the plugin, ' .
-    'but can be overridden on an Item-by-Item basis. ' .
-    '***Use only those folders provided by the System Administrator.***';
+    "but can be overridden on an Item-by-Item basis.\n" .
+    '***Use only those folders specified by the Server Administrator.***';
+const ELEMENT_FOLDER_DESCRIPTION_DEFAULT =
+    'The folder (relative to the account root) '.
+    'where protected audio files will be stored. ' .
+    'This folder will be used when no folder is specified ' .
+    "for the individual Item.\n" .
+    '***Use only those folders specified by the Server Administrator.***';
 const ELEMENT_FOLDER_FIELD = 'stream-only-directory';
+
+const ELEMENT_TIMEOUT_TITLE = 'Timeout';
 const ELEMENT_TIMEOUT = "Timeout";
-const ELEMENT_TIMEOUT_DESCRIPTION = "Number of seconds the protected file is made available to a site visitor";
+const ELEMENT_TIMEOUT_DESCRIPTION =
+"Number of seconds the protected file is made available to a site visitor. " .
+"Setting a lower value may be helpful if your site gets a lot of activity.";
 const ELEMENT_TIMEOUT_FIELD = 'timeout';
+
+// The custom message is not stored as an element
+// It is stored in a file in the files/m3u folder
+const ELEMENT_CUSTOM_MSG_TITLE = 'Custom Message';
+const ELEMENT_CUSTOM_MSG = "Custom message";
+const ELEMENT_CUSTOM_MSG_DESCRIPTION =
+    'Custom text to be downloaded when user tries to download a protected file.';
+const ELEMENT_CUSTOM_MSG_FIELD = 'custom-msg';
 
 // Names of options
 const OPTION_LICENSES = 'so_default_license_count';
 const OPTION_FOLDER = 'so_default_folder';
 const OPTION_TIMEOUT = 'so_timeout';
+const OPTION_CUSTOM_MSG = 'so_custom_msg';
 
 // Defaults for options
 const DEFAULT_LICENSES = 1;
 const DEFAULT_FOLDER = 'so_files';
 CONST DEFAULT_TIMEOUT = 300;
 
-// Must match definitions found in scripts/play.php
+// *** Must match definitions found in scripts/play.php ***
 // Info stored in .m3u file
 const M3U_FILENAME = 0;
 const M3U_FILEID   = 1;
@@ -63,6 +97,16 @@ const SO_PLAYLIST = 'm3u';
 
 // File extension for .m3u files
 const SO_PLAYLIST_EXT = '.m3u';
+
+// File for storing list of reserved files
+const SO_RESERVED_FILES = 'reserved.txt';
+
+// File for storing the custom msg
+const SO_CUSTOM_MSG_FILE = 'custom_msg.txt';
+
+const SO_CUSTOM_MSG_TEXT =
+'The license under which this file is made available for streaming ' .
+'does not permit it to be downloaded.';
 
 // .htaccess rule
 const HTACCESS                = '.htaccess';

--- a/scripts/play.php
+++ b/scripts/play.php
@@ -56,10 +56,10 @@ if (preg_match("#/(\d+).m3u/$#", $_SERVER['PATH_INFO'], $matches)) {
 $m3uFile = $m3uDir . DIRECTORY_SEPARATOR . $m3uID . ".m3u";
 
 $playlist = file($m3uFile);
+
+// Handle unauthorized attempt to download the file.
 if (!$playlist) {
-    // Playlist does not exist. Either our access to it expired,
-    //  (hopefully the JS routines will update the HTML before this happens)
-    //  or this is an unauthorized attempt to download the file.
+    readfile($m3uDir . DIRECTORY_SEPARATOR . "custom_msg.txt");
     exit;
 }
 


### PR DESCRIPTION
* Issue #35 - Allow site owner to specify a custom message to be downloaded when visitor requests download of protected file
* updated literals (constants) for Elements
* updated hookConfigForm() to use literals
* moved retrieval of stored values into config_form.php and deleted two unused methods
* used Omeka error reporting for an additional error in hookUninstall()